### PR TITLE
fixed getHistorical nesting

### DIFF
--- a/Service/OpenExchangeRatesService.php
+++ b/Service/OpenExchangeRatesService.php
@@ -263,11 +263,9 @@ class OpenExchangeRatesService
             'GET',
             $this->getEndPoint().'/historical/'.$date->format('Y-m-d').'.json',
             array(
-                array(
-                    'query' => array(
-                        'app_id' => $this->getAppId(),
-                        'base' => $this->getBaseCurrency()
-                    )
+                'query' => array(
+                    'app_id' => $this->getAppId(),
+                    'base' => $this->getBaseCurrency()
                 )
             )
         );


### PR DESCRIPTION
getHistorical had an extra level of array nesting that prevented the request from succeeding
